### PR TITLE
Scan overlay and scan size

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,10 +46,11 @@ class _MyAppState extends State<MyApp> {
       context: context,
       builder: (context) => CamCodeScanner(
         showDebugFrames: true,
-        showDebugOverlayAnalysisArea: true,
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.height,
-        refreshDelayMillis: 800,
+        refreshDelayMillis: 100,
+        overlayWidth: 400,
+        overlayHeight: 250,
         showOverlay: true,
         scanInsideOverlayOnly: true,
         overlayColor: Colors.blue,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,7 +47,9 @@ class _MyAppState extends State<MyApp> {
       builder: (context) => CamCodeScanner(
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.height,
-        refreshDelayMillis: 800,
+        refreshDelayMillis: 100,
+        showOverlay: true,
+        overlayColor: Colors.blue,
         onBarcodeResult: (barcode) {
           Navigator.of(context).pushNamed('/', arguments: barcode);
         },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,10 +45,13 @@ class _MyAppState extends State<MyApp> {
     showDialog(
       context: context,
       builder: (context) => CamCodeScanner(
+        showDebugFrames: true,
+        showDebugOverlayAnalysisArea: true,
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.height,
-        refreshDelayMillis: 100,
+        refreshDelayMillis: 800,
         showOverlay: true,
+        scanInsideOverlayOnly: true,
         overlayColor: Colors.blue,
         onBarcodeResult: (barcode) {
           Navigator.of(context).pushNamed('/', arguments: barcode);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,6 +51,7 @@ class _MyAppState extends State<MyApp> {
         refreshDelayMillis: 100,
         overlayWidth: 400,
         overlayHeight: 250,
+        overlayAnimationDuration: 800,
         showOverlay: true,
         scanInsideOverlayOnly: true,
         overlayColor: Colors.blue,

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -30,6 +30,12 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <style>
+    .imgPreview{
+      object-fit: scale-down;
+    }
+  </style>
+
   <!-- The core Firebase JS SDK is always required and must be listed first -->
   <script src="/__/firebase/8.2.9/firebase-app.js"></script>
 

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -32,7 +32,7 @@
 <body>
   <style>
     .imgPreview{
-      object-fit: scale-down;
+      object-fit: contain;
     }
   </style>
 

--- a/lib/cam_code_scanner.dart
+++ b/lib/cam_code_scanner.dart
@@ -136,8 +136,8 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
                 child: Opacity(
                   opacity: 0.2,
                   child: Container(
-                    width: bounds.width + 20,
-                    height: bounds.height + 20,
+                    width: bounds.width,
+                    height: bounds.height,
                     color: Colors.black,
                   ),
                 ),

--- a/lib/cam_code_scanner.dart
+++ b/lib/cam_code_scanner.dart
@@ -177,7 +177,7 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
                     alignment: Alignment.center,
                     child: Stack(
                       children: [
-                        CamcodeOverlayPaint(
+                        CamcodeOverlay(
                           key: _overlayKey,
                           overlayColor: widget.overlayColor,
                           width: widget.overlayWidth,

--- a/lib/cam_code_scanner.dart
+++ b/lib/cam_code_scanner.dart
@@ -15,9 +15,6 @@ class CamCodeScanner extends StatefulWidget {
   // shows the current analysing picture
   final bool showDebugFrames;
 
-  // shows the current part of the video feed being analysed for barcodes
-  final bool showDebugOverlayAnalysisArea;
-
   // call back to trigger on barcode result
   final Function onBarcodeResult;
 
@@ -55,7 +52,6 @@ class CamCodeScanner extends StatefulWidget {
   /// * refreshDelayMillis - delay between to picture analysis
   CamCodeScanner({
     this.showDebugFrames = false,
-    this.showDebugOverlayAnalysisArea = false,
     required this.onBarcodeResult,
     required this.width,
     required this.height,
@@ -123,27 +119,9 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
           // Send the overlay size informations to the platform channel
           // for image analysis
           channel.invokeMethod('defineScanzone', [
-            bounds.left,
-            bounds.top,
             bounds.width,
             bounds.height,
           ]);
-
-          if (widget.showDebugOverlayAnalysisArea) {
-            setState(() {
-              debugOverlayAnalysisArea = Positioned.fromRect(
-                rect: bounds,
-                child: Opacity(
-                  opacity: 0.2,
-                  child: Container(
-                    width: bounds.width,
-                    height: bounds.height,
-                    color: Colors.black,
-                  ),
-                ),
-              );
-            });
-          }
         }
       });
     }
@@ -197,17 +175,25 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
                 if (widget.showOverlay)
                   Align(
                     alignment: Alignment.center,
-                    child: CamcodeOverlayPaint(
-                      key: _overlayKey,
-                      overlayColor: widget.overlayColor,
-                      width: widget.overlayWidth,
-                      height: widget.overlayHeight,
+                    child: Stack(
+                      children: [
+                        CamcodeOverlayPaint(
+                          key: _overlayKey,
+                          overlayColor: widget.overlayColor,
+                          width: widget.overlayWidth,
+                          height: widget.overlayHeight,
+                        ),
+                        Opacity(
+                          opacity: 0.2,
+                          child: Container(
+                            width: widget.overlayWidth,
+                            height: widget.overlayHeight,
+                            color: Colors.black,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                if (widget.showOverlay &&
-                    widget.showDebugOverlayAnalysisArea &&
-                    debugOverlayAnalysisArea != null)
-                  debugOverlayAnalysisArea!,
                 Align(
                   alignment: Alignment.bottomCenter,
                   child: Padding(

--- a/lib/cam_code_scanner.dart
+++ b/lib/cam_code_scanner.dart
@@ -15,6 +15,9 @@ class CamCodeScanner extends StatefulWidget {
   // shows the current analysing picture
   final bool showDebugFrames;
 
+  // shows the current part of the video feed being analysed for barcodes
+  final bool showDebugOverlayAnalysisArea;
+
   // call back to trigger on barcode result
   final Function onBarcodeResult;
 
@@ -52,14 +55,15 @@ class CamCodeScanner extends StatefulWidget {
   /// * refreshDelayMillis - delay between to picture analysis
   CamCodeScanner({
     this.showDebugFrames = false,
+    this.showDebugOverlayAnalysisArea = false,
     required this.onBarcodeResult,
     required this.width,
     required this.height,
     this.showOverlay = false,
     this.overlayColor = Colors.black,
     this.scanInsideOverlayOnly = false,
-    this.overlayWidth = 400,
-    this.overlayHeight = 240, // 240 is 400 * 0.6
+    this.overlayWidth = 100,
+    this.overlayHeight = 100, // 240 is 400 * 0.6
     this.refreshDelayMillis = 400,
   });
 
@@ -78,6 +82,7 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
   String barcode = '';
   // Used to know if camera is loading or initialized
   bool initialized = false;
+  Widget? debugOverlayAnalysisArea = null;
 
   final _overlayKey = GlobalKey();
   final _overlayContainerKey = GlobalKey();
@@ -123,6 +128,22 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
             bounds.width,
             bounds.height,
           ]);
+
+          if (widget.showDebugOverlayAnalysisArea) {
+            setState(() {
+              debugOverlayAnalysisArea = Positioned.fromRect(
+                rect: bounds,
+                child: Opacity(
+                  opacity: 0.2,
+                  child: Container(
+                    width: bounds.width + 20,
+                    height: bounds.height + 20,
+                    color: Colors.black,
+                  ),
+                ),
+              );
+            });
+          }
         }
       });
     }
@@ -183,6 +204,10 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
                       height: 400 * 0.6,
                     ),
                   ),
+                if (widget.showOverlay &&
+                    widget.showDebugOverlayAnalysisArea &&
+                    debugOverlayAnalysisArea != null)
+                  debugOverlayAnalysisArea!,
                 Align(
                   alignment: Alignment.bottomCenter,
                   child: Padding(

--- a/lib/cam_code_scanner.dart
+++ b/lib/cam_code_scanner.dart
@@ -111,7 +111,7 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
       initialized = true;
     });
 
-    if (SchedulerBinding.instance != null) {
+    if (widget.scanInsideOverlayOnly && SchedulerBinding.instance != null) {
       SchedulerBinding.instance!.addPostFrameCallback((timeStamp) {
         final bounds = _overlayKey.globalPaintBounds;
 

--- a/lib/cam_code_scanner.dart
+++ b/lib/cam_code_scanner.dart
@@ -86,7 +86,6 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
   Widget? debugOverlayAnalysisArea;
 
   final _overlayKey = GlobalKey();
-  final _overlayContainerKey = GlobalKey();
 
   @override
   void initState() {
@@ -160,7 +159,6 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
         },
         child: Builder(
           builder: (context) => Center(
-            key: _overlayContainerKey,
             child: Stack(
               children: <Widget>[
                 initialized
@@ -180,24 +178,12 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
                 if (widget.showOverlay)
                   Align(
                     alignment: Alignment.center,
-                    child: Stack(
-                      children: [
-                        CamcodeOverlay(
-                          key: _overlayKey,
-                          overlayColor: widget.overlayColor,
-                          width: widget.overlayWidth,
-                          height: widget.overlayHeight,
-                          animationDuration: widget.overlayAnimationDuration,
-                        ),
-                        Opacity(
-                          opacity: 0.2,
-                          child: Container(
-                            width: widget.overlayWidth,
-                            height: widget.overlayHeight,
-                            color: Colors.black,
-                          ),
-                        ),
-                      ],
+                    child: CamcodeOverlay(
+                      key: _overlayKey,
+                      overlayColor: widget.overlayColor,
+                      width: widget.overlayWidth,
+                      height: widget.overlayHeight,
+                      animationDuration: widget.overlayAnimationDuration,
                     ),
                   ),
                 Align(

--- a/lib/cam_code_scanner.dart
+++ b/lib/cam_code_scanner.dart
@@ -62,8 +62,8 @@ class CamCodeScanner extends StatefulWidget {
     this.showOverlay = false,
     this.overlayColor = Colors.black,
     this.scanInsideOverlayOnly = false,
-    this.overlayWidth = 100,
-    this.overlayHeight = 100, // 240 is 400 * 0.6
+    this.overlayWidth = 400,
+    this.overlayHeight = 240, // 240 is 400 * 0.6
     this.refreshDelayMillis = 400,
   });
 
@@ -82,7 +82,7 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
   String barcode = '';
   // Used to know if camera is loading or initialized
   bool initialized = false;
-  Widget? debugOverlayAnalysisArea = null;
+  Widget? debugOverlayAnalysisArea;
 
   final _overlayKey = GlobalKey();
   final _overlayContainerKey = GlobalKey();
@@ -190,8 +190,8 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
                 !widget.showDebugFrames
                     ? Container()
                     : SizedBox(
-                        width: 100,
                         height: 100,
+                        width: 100,
                         child: _imageWidget,
                       ),
                 if (widget.showOverlay)
@@ -200,8 +200,8 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
                     child: CamcodeOverlayPaint(
                       key: _overlayKey,
                       overlayColor: widget.overlayColor,
-                      width: 400,
-                      height: 400 * 0.6,
+                      width: widget.overlayWidth,
+                      height: widget.overlayHeight,
                     ),
                   ),
                 if (widget.showOverlay &&

--- a/lib/cam_code_scanner.dart
+++ b/lib/cam_code_scanner.dart
@@ -44,6 +44,10 @@ class CamCodeScanner extends StatefulWidget {
   // Overrides the default height of the overlay
   final double overlayHeight;
 
+  // Animation duration for the scan overlay, in milliseconds.
+  // Defaults to -1, which indicates no animation.
+  final int overlayAnimationDuration;
+
   /// Camera barcode scanner widget
   /// Params:
   /// * showDebugFrames [true|false] - shows the current analysing picture
@@ -61,6 +65,7 @@ class CamCodeScanner extends StatefulWidget {
     this.overlayWidth = 400,
     this.overlayHeight = 240, // 240 is 400 * 0.6
     this.refreshDelayMillis = 400,
+    this.overlayAnimationDuration = -1,
   });
 
   @override
@@ -182,6 +187,7 @@ class _CamCodeScannerState extends State<CamCodeScanner> {
                           overlayColor: widget.overlayColor,
                           width: widget.overlayWidth,
                           height: widget.overlayHeight,
+                          animationDuration: widget.overlayAnimationDuration,
                         ),
                         Opacity(
                           opacity: 0.2,

--- a/lib/camcode_overlay.dart
+++ b/lib/camcode_overlay.dart
@@ -22,15 +22,17 @@ class CamcodeOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: [
+        // Custom path square to define scanning zone
         CustomPaint(
           size: Size(
             width,
             height,
           ),
-          painter: _RPSCustomPainter(
+          painter: _ScannerCustomPainter(
             overlayColor: overlayColor,
           ),
         ),
+        // Animated line
         if (animationDuration > 0)
           _AnimatedScannerBar(
             color: overlayColor,
@@ -38,6 +40,15 @@ class CamcodeOverlay extends StatelessWidget {
             maxHeight: height,
             animationDuration: animationDuration,
           ),
+        // Black transparent background for the scaning zone
+        Opacity(
+          opacity: 0.2,
+          child: Container(
+            width: width,
+            height: height,
+            color: Colors.black,
+          ),
+        ),
       ],
     );
   }
@@ -112,68 +123,58 @@ class __AnimatedScannerBarState extends State<_AnimatedScannerBar>
   }
 }
 
-class _RPSCustomPainter extends CustomPainter {
+class _ScannerCustomPainter extends CustomPainter {
   final Color overlayColor;
 
-  _RPSCustomPainter({
+  _ScannerCustomPainter({
     required this.overlayColor,
   });
 
   @override
   void paint(Canvas canvas, Size size) {
-    final upperLeftPaint = Paint()
+    final strokeWidth = 5.0;
+
+    // Most of the code here was generated using the online tool here:
+    // https://shapemaker.web.app/#/
+    // Then it was refactored for code clarity
+    final painter = Paint()
       ..color = overlayColor
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 5.03;
+      ..strokeWidth = strokeWidth;
 
     final upperLeftPath = Path()
       ..moveTo(size.width * 0.1920286, size.height * 0.0137500)
       ..lineTo(size.width * 0.0078000, size.height * 0.0121500)
       ..lineTo(size.width * 0.0077429, size.height * 0.3374500);
 
-    canvas.drawPath(upperLeftPath, upperLeftPaint);
-
-    final upperRightPaint = Paint()
-      ..color = overlayColor
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 5.03;
+    canvas.drawPath(upperLeftPath, painter);
 
     final upperRightPath = Path()
       ..moveTo(size.width * 0.9879143, size.height * 0.6623500)
       ..lineTo(size.width * 0.9885714, size.height * 0.9800000)
       ..lineTo(size.width * 0.8041143, size.height * 0.9811500);
 
-    canvas.drawPath(upperRightPath, upperRightPaint);
-
-    final lowerRightPaint = Paint()
-      ..color = overlayColor
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 5.03;
+    canvas.drawPath(upperRightPath, painter);
 
     final lowerRightPath = Path()
       ..moveTo(size.width * 0.1907429, size.height * 0.9818000)
       ..lineTo(size.width * 0.0085714, size.height * 0.9800000)
       ..lineTo(size.width * 0.0085714, size.height * 0.6650000);
 
-    canvas.drawPath(lowerRightPath, lowerRightPaint);
-
-    final lowerLeftPaint = Paint()
-      ..color = overlayColor
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 5.03;
+    canvas.drawPath(lowerRightPath, painter);
 
     final lowerLeftPath = Path()
       ..moveTo(size.width * 0.8091143, size.height * 0.0086500)
       ..lineTo(size.width * 0.9887143, size.height * 0.0087000)
       ..lineTo(size.width * 0.9878000, size.height * 0.3380000);
 
-    canvas.drawPath(lowerLeftPath, lowerLeftPaint);
+    canvas.drawPath(lowerLeftPath, painter);
   }
 
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) {
     final shouldRepaint =
-        overlayColor != (oldDelegate as _RPSCustomPainter).overlayColor;
+        overlayColor != (oldDelegate as _ScannerCustomPainter).overlayColor;
 
     return shouldRepaint;
   }

--- a/lib/camcode_overlay.dart
+++ b/lib/camcode_overlay.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 
-class CamcodeOverlayPaint extends StatelessWidget {
-  CamcodeOverlayPaint({
-    Key? key,
-    this.width = 400,
-    this.height = -1,
-    this.overlayColor = Colors.black,
-  }) : super(key: key) {
+class CamcodeOverlay extends StatelessWidget {
+  CamcodeOverlay(
+      {Key? key,
+      this.width = 400,
+      this.height = -1,
+      this.overlayColor = Colors.black,
+      this.animationDuration = -1})
+      : super(key: key) {
     if (height < 0) {
       height = width * 0.6;
     }
@@ -14,19 +15,120 @@ class CamcodeOverlayPaint extends StatelessWidget {
 
   final Color overlayColor;
   final double width;
+  final int animationDuration;
   late double height;
 
   @override
   Widget build(BuildContext context) {
-    return CustomPaint(
-      size: Size(
-        width,
-        height,
-      ),
-      painter: _RPSCustomPainter(
-        overlayColor: overlayColor,
-      ),
+    return Stack(
+      children: [
+        CustomPaint(
+          size: Size(
+            width,
+            height,
+          ),
+          painter: _RPSCustomPainter(
+            overlayColor: overlayColor,
+          ),
+        ),
+        if (animationDuration > 0)
+          _AnimatedScannerBar(
+            color: overlayColor,
+            maxWidth: width,
+            maxHeight: height,
+            animationDuration: animationDuration,
+          ),
+      ],
     );
+  }
+}
+
+class _AnimatedScannerBar extends StatefulWidget {
+  _AnimatedScannerBar({
+    Key? key,
+    required this.color,
+    required this.maxWidth,
+    required this.maxHeight,
+    this.animationDuration = 800,
+  }) : super(key: key);
+
+  final Color color;
+  final double maxWidth;
+  final double maxHeight;
+  final int animationDuration;
+
+  @override
+  __AnimatedScannerBarState createState() => __AnimatedScannerBarState();
+}
+
+class __AnimatedScannerBarState extends State<_AnimatedScannerBar>
+    with TickerProviderStateMixin {
+  late AnimationController widthController;
+  late Animation<double> widthAnimation;
+
+  late AnimationController positionController;
+  late Animation<double> positionAnimation;
+
+  @override
+  void dispose() {
+    widthController.stop();
+    widthController.dispose();
+
+    positionController.stop();
+    positionController.dispose();
+
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _setupWidthAnimation();
+    _setupHeightAnimation();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      child: Container(
+        height: 2,
+        color: widget.color,
+        width: widget.maxWidth,
+      ),
+      left: 0,
+      top: positionAnimation.value,
+    );
+  }
+
+  void _setupWidthAnimation() {
+    widthController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: widget.animationDuration),
+    );
+    widthAnimation = Tween<double>(
+      begin: widget.maxWidth / 4,
+      end: widget.maxWidth,
+    ).animate(widthController);
+    widthController.addListener(() {
+      setState(() {});
+    });
+    // widthController.repeat(reverse: true);
+  }
+
+  void _setupHeightAnimation() {
+    positionController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: widget.animationDuration * 2),
+    );
+    positionAnimation = Tween<double>(
+      begin: 0,
+      end: widget.maxHeight,
+    ).animate(positionController);
+    positionController.addListener(() {
+      setState(() {});
+    });
+    positionController.repeat(reverse: true);
   }
 }
 
@@ -39,57 +141,60 @@ class _RPSCustomPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final paint_0 = Paint()
+    final upperLeftPaint = Paint()
       ..color = overlayColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = 5.03;
 
-    final path_0 = Path();
-    path_0.moveTo(size.width * 0.1920286, size.height * 0.0137500);
-    path_0.lineTo(size.width * 0.0078000, size.height * 0.0121500);
-    path_0.lineTo(size.width * 0.0077429, size.height * 0.3374500);
+    final upperLeftPath = Path()
+      ..moveTo(size.width * 0.1920286, size.height * 0.0137500)
+      ..lineTo(size.width * 0.0078000, size.height * 0.0121500)
+      ..lineTo(size.width * 0.0077429, size.height * 0.3374500);
 
-    canvas.drawPath(path_0, paint_0);
+    canvas.drawPath(upperLeftPath, upperLeftPaint);
 
-    final paint_1 = Paint()
+    final upperRightPaint = Paint()
       ..color = overlayColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = 5.03;
 
-    final path_1 = Path();
-    path_1.moveTo(size.width * 0.9879143, size.height * 0.6623500);
-    path_1.lineTo(size.width * 0.9885714, size.height * 0.9800000);
-    path_1.lineTo(size.width * 0.8041143, size.height * 0.9811500);
+    final upperRightPath = Path()
+      ..moveTo(size.width * 0.9879143, size.height * 0.6623500)
+      ..lineTo(size.width * 0.9885714, size.height * 0.9800000)
+      ..lineTo(size.width * 0.8041143, size.height * 0.9811500);
 
-    canvas.drawPath(path_1, paint_1);
+    canvas.drawPath(upperRightPath, upperRightPaint);
 
-    final paint_2 = Paint()
+    final lowerRightPaint = Paint()
       ..color = overlayColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = 5.03;
 
-    final path_2 = Path();
-    path_2.moveTo(size.width * 0.1907429, size.height * 0.9818000);
-    path_2.lineTo(size.width * 0.0085714, size.height * 0.9800000);
-    path_2.lineTo(size.width * 0.0085714, size.height * 0.6650000);
+    final lowerRightPath = Path()
+      ..moveTo(size.width * 0.1907429, size.height * 0.9818000)
+      ..lineTo(size.width * 0.0085714, size.height * 0.9800000)
+      ..lineTo(size.width * 0.0085714, size.height * 0.6650000);
 
-    canvas.drawPath(path_2, paint_2);
+    canvas.drawPath(lowerRightPath, lowerRightPaint);
 
-    final paint_3 = Paint()
+    final lowerLeftPaint = Paint()
       ..color = overlayColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = 5.03;
 
-    final path_3 = Path();
-    path_3.moveTo(size.width * 0.8091143, size.height * 0.0086500);
-    path_3.lineTo(size.width * 0.9887143, size.height * 0.0087000);
-    path_3.lineTo(size.width * 0.9878000, size.height * 0.3380000);
+    final lowerLeftPath = Path()
+      ..moveTo(size.width * 0.8091143, size.height * 0.0086500)
+      ..lineTo(size.width * 0.9887143, size.height * 0.0087000)
+      ..lineTo(size.width * 0.9878000, size.height * 0.3380000);
 
-    canvas.drawPath(path_3, paint_3);
+    canvas.drawPath(lowerLeftPath, lowerLeftPaint);
   }
 
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) {
-    return overlayColor != (oldDelegate as _RPSCustomPainter).overlayColor;
+    final shouldRepaint =
+        overlayColor != (oldDelegate as _RPSCustomPainter).overlayColor;
+
+    return shouldRepaint;
   }
 }

--- a/lib/camcode_overlay.dart
+++ b/lib/camcode_overlay.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+class CamcodeOverlayPaint extends StatelessWidget {
+  CamcodeOverlayPaint({
+    Key? key,
+    this.width = 400,
+    this.height = -1,
+    this.overlayColor = Colors.black,
+  }) : super(key: key) {
+    if (height < 0) {
+      height = width * 0.6;
+    }
+  }
+
+  final Color overlayColor;
+  final double width;
+  late double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: Size(
+        width,
+        height,
+      ),
+      painter: _RPSCustomPainter(
+        overlayColor: overlayColor,
+      ),
+    );
+  }
+}
+
+class _RPSCustomPainter extends CustomPainter {
+  final Color overlayColor;
+
+  _RPSCustomPainter({
+    required this.overlayColor,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint_0 = Paint()
+      ..color = overlayColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 5.03;
+
+    final path_0 = Path();
+    path_0.moveTo(size.width * 0.1920286, size.height * 0.0137500);
+    path_0.lineTo(size.width * 0.0078000, size.height * 0.0121500);
+    path_0.lineTo(size.width * 0.0077429, size.height * 0.3374500);
+
+    canvas.drawPath(path_0, paint_0);
+
+    final paint_1 = Paint()
+      ..color = overlayColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 5.03;
+
+    final path_1 = Path();
+    path_1.moveTo(size.width * 0.9879143, size.height * 0.6623500);
+    path_1.lineTo(size.width * 0.9885714, size.height * 0.9800000);
+    path_1.lineTo(size.width * 0.8041143, size.height * 0.9811500);
+
+    canvas.drawPath(path_1, paint_1);
+
+    final paint_2 = Paint()
+      ..color = overlayColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 5.03;
+
+    final path_2 = Path();
+    path_2.moveTo(size.width * 0.1907429, size.height * 0.9818000);
+    path_2.lineTo(size.width * 0.0085714, size.height * 0.9800000);
+    path_2.lineTo(size.width * 0.0085714, size.height * 0.6650000);
+
+    canvas.drawPath(path_2, paint_2);
+
+    final paint_3 = Paint()
+      ..color = overlayColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 5.03;
+
+    final path_3 = Path();
+    path_3.moveTo(size.width * 0.8091143, size.height * 0.0086500);
+    path_3.lineTo(size.width * 0.9887143, size.height * 0.0087000);
+    path_3.lineTo(size.width * 0.9878000, size.height * 0.3380000);
+
+    canvas.drawPath(path_3, paint_3);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return overlayColor != (oldDelegate as _RPSCustomPainter).overlayColor;
+  }
+}

--- a/lib/camcode_overlay.dart
+++ b/lib/camcode_overlay.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
 class CamcodeOverlay extends StatelessWidget {
-  CamcodeOverlay(
-      {Key? key,
-      this.width = 400,
-      this.height = -1,
-      this.overlayColor = Colors.black,
-      this.animationDuration = -1})
-      : super(key: key) {
+  CamcodeOverlay({
+    Key? key,
+    this.width = 400,
+    this.height = -1,
+    this.overlayColor = Colors.black,
+    this.animationDuration = -1,
+  }) : super(key: key) {
     if (height < 0) {
       height = width * 0.6;
     }
@@ -62,18 +62,12 @@ class _AnimatedScannerBar extends StatefulWidget {
 }
 
 class __AnimatedScannerBarState extends State<_AnimatedScannerBar>
-    with TickerProviderStateMixin {
-  late AnimationController widthController;
-  late Animation<double> widthAnimation;
-
+    with SingleTickerProviderStateMixin {
   late AnimationController positionController;
   late Animation<double> positionAnimation;
 
   @override
   void dispose() {
-    widthController.stop();
-    widthController.dispose();
-
     positionController.stop();
     positionController.dispose();
 
@@ -84,36 +78,25 @@ class __AnimatedScannerBarState extends State<_AnimatedScannerBar>
   void initState() {
     super.initState();
 
-    _setupWidthAnimation();
     _setupHeightAnimation();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Positioned(
+    return AnimatedBuilder(
+      animation: positionController,
       child: Container(
         height: 2,
         color: widget.color,
         width: widget.maxWidth,
       ),
-      left: 0,
-      top: positionAnimation.value,
+      builder: (context, child) {
+        return Positioned(
+          child: child!,
+          top: positionAnimation.value,
+        );
+      },
     );
-  }
-
-  void _setupWidthAnimation() {
-    widthController = AnimationController(
-      vsync: this,
-      duration: Duration(milliseconds: widget.animationDuration),
-    );
-    widthAnimation = Tween<double>(
-      begin: widget.maxWidth / 4,
-      end: widget.maxWidth,
-    ).animate(widthController);
-    widthController.addListener(() {
-      setState(() {});
-    });
-    // widthController.repeat(reverse: true);
   }
 
   void _setupHeightAnimation() {
@@ -125,9 +108,6 @@ class __AnimatedScannerBarState extends State<_AnimatedScannerBar>
       begin: 0,
       end: widget.maxHeight,
     ).animate(positionController);
-    positionController.addListener(() {
-      setState(() {});
-    });
     positionController.repeat(reverse: true);
   }
 }

--- a/lib/camcode_web.dart
+++ b/lib/camcode_web.dart
@@ -201,8 +201,8 @@ class CamcodeWeb {
     image = context.getImageData(
       0,
       0,
-      _canvasElement.width ?? 0,
-      _canvasElement.height ?? 0,
+      _webcamVideoElement.width,
+      _webcamVideoElement.height,
     );
 
     final dataUrl = _canvasElement.toDataUrl('image/png');

--- a/lib/camcode_web.dart
+++ b/lib/camcode_web.dart
@@ -50,10 +50,8 @@ class CamcodeWeb {
           arguments[2],
         );
       case 'defineScanzone':
-        _scanZoneX = call.arguments.length > 0 ? call.arguments[0] : null;
-        _scanZoneY = call.arguments.length > 1 ? call.arguments[1] : null;
-        _scanZoneWidth = call.arguments.length > 2 ? call.arguments[2] : null;
-        _scanZoneHeight = call.arguments.length > 3 ? call.arguments[3] : null;
+        _scanZoneWidth = call.arguments.length > 0 ? call.arguments[0] : null;
+        _scanZoneHeight = call.arguments.length > 1 ? call.arguments[1] : null;
         break;
       case 'releaseResources':
         return releaseResources();
@@ -72,8 +70,6 @@ class CamcodeWeb {
     return completer.future;
   }
 
-  int? _scanZoneX;
-  int? _scanZoneY;
   double? _scanZoneWidth;
   double? _scanZoneHeight;
 
@@ -151,8 +147,6 @@ class CamcodeWeb {
       _timer = Timer.periodic(Duration(milliseconds: refreshDelayMillis),
           (timer) async {
         _takePicture(
-          _scanZoneX,
-          _scanZoneY,
           _scanZoneWidth,
           _scanZoneHeight,
         );
@@ -165,8 +159,6 @@ class CamcodeWeb {
   /// Takes a picture of the current camera image
   /// and process it for barcode identification
   void _takePicture(
-    int? scanZoneX,
-    int? scanZoneY,
     double? scanZoneWidth,
     double? scanZoneHeight,
   ) async {
@@ -176,29 +168,21 @@ class CamcodeWeb {
     );
     final context = _canvasElement.context2D;
 
+    // Gets a pice of scanZoneWidth * scanZoneHeight pixels, starting from
+    // the center of the video feed
+    // Multiply the end result by a factor (3 here) to "zoom in" on those pixels
+    // while preserving the desired image ratio
     context.drawImageScaledFromSource(
       _webcamVideoElement,
+      (_canvasElement.width ?? 0) / 2 - (scanZoneWidth ?? 0) / 2,
+      (_canvasElement.height ?? 0) / 2 - (scanZoneHeight ?? 0) / 2,
+      scanZoneWidth ?? 0,
+      scanZoneHeight ?? 0,
       0,
       0,
-      (_canvasElement.width ?? 0),
-      (_canvasElement.height ?? 0),
-      0,
-      0,
-      (_canvasElement.width ?? 0),
-      (_canvasElement.height ?? 0),
+      (scanZoneWidth ?? 0) * 2,
+      (scanZoneHeight ?? 0) * 2,
     );
-
-    // context.drawImageScaledFromSource(
-    //   _webcamVideoElement,
-    //   150,
-    //   150,
-    //   scanZoneWidth?.toInt() ?? 0,
-    //   scanZoneHeight?.toInt() ?? 0,
-    //   0,
-    //   0,
-    //   (_canvasElement.width ?? 0),
-    //   (_canvasElement.height ?? 0),
-    // );
 
     image = context.getImageData(
       0,

--- a/lib/camcode_web.dart
+++ b/lib/camcode_web.dart
@@ -99,8 +99,9 @@ class CamcodeWeb {
     _webcamVideoElement.setAttribute('playsinline', 'true');
 
     imageElement = ImageElement()
-      ..width = 320
-      ..height = 320;
+      ..width = 500
+      ..height = 320
+      ..className = 'imgPreview';
 
     // Register an webcam
 
@@ -174,20 +175,26 @@ class CamcodeWeb {
       height: _webcamVideoElement.height,
     );
     final context = _canvasElement.context2D;
-    // TODO: Reduce size of image allowing to detect barcodes
-    context.drawImageScaled(
+
+    context.drawImageScaledFromSource(
       _webcamVideoElement,
-      scanZoneX ?? 0,
-      scanZoneY ?? 0,
-      scanZoneWidth ?? _webcamVideoElement.width,
-      scanZoneHeight ?? _webcamVideoElement.height,
+      150,
+      150,
+      scanZoneWidth?.toInt() ?? 0,
+      scanZoneHeight?.toInt() ?? 0,
+      0,
+      0,
+      (_canvasElement.width ?? 0),
+      (_canvasElement.height ?? 0),
     );
+
     image = context.getImageData(
-      scanZoneX ?? 0,
-      scanZoneY ?? 0,
-      scanZoneWidth?.toInt() ?? _canvasElement.width ?? 0,
-      scanZoneHeight?.toInt() ?? _canvasElement.height ?? 0,
+      0,
+      0,
+      _canvasElement.width ?? 0,
+      _canvasElement.height ?? 0,
     );
+
     final dataUrl = _canvasElement.toDataUrl('image/png');
     imageElement.src = dataUrl;
 

--- a/lib/camcode_web.dart
+++ b/lib/camcode_web.dart
@@ -52,6 +52,8 @@ class CamcodeWeb {
       case 'defineScanzone':
         _scanZoneWidth = call.arguments.length > 0 ? call.arguments[0] : null;
         _scanZoneHeight = call.arguments.length > 1 ? call.arguments[1] : null;
+        imageElement.width = _scanZoneWidth?.toInt() ?? imageElement.width;
+        imageElement.height = _scanZoneHeight?.toInt() ?? imageElement.height;
         break;
       case 'releaseResources':
         return releaseResources();
@@ -168,21 +170,33 @@ class CamcodeWeb {
     );
     final context = _canvasElement.context2D;
 
-    // Gets a pice of scanZoneWidth * scanZoneHeight pixels, starting from
-    // the center of the video feed
-    // Multiply the end result by a factor (3 here) to "zoom in" on those pixels
-    // while preserving the desired image ratio
-    context.drawImageScaledFromSource(
-      _webcamVideoElement,
-      (_canvasElement.width ?? 0) / 2 - (scanZoneWidth ?? 0) / 2,
-      (_canvasElement.height ?? 0) / 2 - (scanZoneHeight ?? 0) / 2,
-      scanZoneWidth ?? 0,
-      scanZoneHeight ?? 0,
-      0,
-      0,
-      (scanZoneWidth ?? 0) * 2,
-      (scanZoneHeight ?? 0) * 2,
-    );
+    if (scanZoneWidth != null && scanZoneHeight != null) {
+      // Gets a pice of scanZoneWidth * scanZoneHeight pixels, starting from
+      // the center of the video feed
+      // Multiply the end result by a factor (3 here) to "zoom in" on those pixels
+      // while preserving the desired image ratio
+      context.drawImageScaledFromSource(
+        _webcamVideoElement,
+        (_canvasElement.width ?? 0) / 2 - scanZoneWidth / 2,
+        (_canvasElement.height ?? 0) / 2 - scanZoneHeight / 2,
+        scanZoneWidth,
+        scanZoneHeight,
+        0,
+        0,
+        scanZoneWidth * 2,
+        scanZoneHeight * 2,
+      );
+    } else {
+      // If no overlay is specified, use the whole video feed as an input source
+      // for the codebar search
+      context.drawImageScaled(
+        _webcamVideoElement,
+        0,
+        0,
+        _canvasElement.width ?? 0,
+        _canvasElement.height ?? 0,
+      );
+    }
 
     image = context.getImageData(
       0,

--- a/lib/camcode_web.dart
+++ b/lib/camcode_web.dart
@@ -99,8 +99,8 @@ class CamcodeWeb {
     _webcamVideoElement.setAttribute('playsinline', 'true');
 
     imageElement = ImageElement()
-      ..width = 500
-      ..height = 320
+      ..width = 300
+      ..height = 300
       ..className = 'imgPreview';
 
     // Register an webcam
@@ -171,22 +171,34 @@ class CamcodeWeb {
     double? scanZoneHeight,
   ) async {
     final _canvasElement = CanvasElement(
-      width: _webcamVideoElement.width,
-      height: _webcamVideoElement.height,
+      width: _webcamVideoElement.videoWidth,
+      height: _webcamVideoElement.videoHeight,
     );
     final context = _canvasElement.context2D;
 
     context.drawImageScaledFromSource(
       _webcamVideoElement,
-      150,
-      150,
-      scanZoneWidth?.toInt() ?? 0,
-      scanZoneHeight?.toInt() ?? 0,
+      0,
+      0,
+      (_canvasElement.width ?? 0),
+      (_canvasElement.height ?? 0),
       0,
       0,
       (_canvasElement.width ?? 0),
       (_canvasElement.height ?? 0),
     );
+
+    // context.drawImageScaledFromSource(
+    //   _webcamVideoElement,
+    //   150,
+    //   150,
+    //   scanZoneWidth?.toInt() ?? 0,
+    //   scanZoneHeight?.toInt() ?? 0,
+    //   0,
+    //   0,
+    //   (_canvasElement.width ?? 0),
+    //   (_canvasElement.height ?? 0),
+    // );
 
     image = context.getImageData(
       0,

--- a/lib/extensions.dart
+++ b/lib/extensions.dart
@@ -1,0 +1,16 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+extension GlobalKeyExtension on GlobalKey {
+  Rect? get globalPaintBounds {
+    final renderObject = currentContext?.findRenderObject();
+    var translation = renderObject?.getTransformTo(null).getTranslation();
+    if (translation != null && renderObject?.paintBounds != null) {
+      return renderObject!.paintBounds
+          .shift(Offset(translation.x, translation.y));
+    } else {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
The goal of the PR is to add two main things:
- a customizable scan overlay to help user understands where he should position the desired barcode
- The ability to scan only a portion of the camera feed, to help reduce false results when scanning multiple barcodes at the same time.

Known issues: 
-The overlay animation has very poor performance when executed on mobile. Might have to be disabled by default on mobile (or implemented using something like a Lottie animation, to see if the performances improve ?)
- The image used for barcode analysis is actually bigger than the visual scan zone on the screen. This is due to the ratio issues between a flutter widget size, and the actual video feed resolution. Needs to be worked out by applying a multiplier to the values used to calculate the image portion

Demo here: https://flutter-scan-adeo.web.app